### PR TITLE
Fix deploy_aws task in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,4 +113,4 @@ namespace :spec do
 end
 
 desc 'Does all needed steps to deploy to aws'
-task :deploy_aws => ['docker:build_latest', 'spec:opevpn', 'docker:tag_aws', 'docker:push_aws']
+task :deploy_aws => ['docker:build_latest', 'spec:openvpn', 'docker:tag_aws', 'docker:push_aws']


### PR DESCRIPTION
The `deploy_aws` task in the Rakefile was attempting to run a `spec:opevpn` task. This task name contains a typo, as it should say `spec:openvpn`. This change corrects the typo, which allows the `deploy_aws` task to be executed.