### PR TITLE
Fix rm in Base Dockerfile

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 RUN (apk -Uuv add --no-cache openvpn iptables ca-certificates && \
-  rm /var/cache/apk/*)
+  rm -f /var/cache/apk/*)
 ONBUILD COPY openvpn /etc/openvpn
 ONBUILD WORKDIR /etc/openvpn
 ONBUILD RUN (mkdir -p /dev/net && \


### PR DESCRIPTION
The Base Dockerfile calls `rm /var/cache/apk/*`. The command will fail if the directory does not exist. By adding the `-f` flag, the command will succeed regardless of whether or not the directory exists.